### PR TITLE
Add Opus 4.8 + Fable 5, plus per-provider model-update skills

### DIFF
--- a/.claude/skills/update-claude-model/SKILL.md
+++ b/.claude/skills/update-claude-model/SKILL.md
@@ -1,37 +1,51 @@
 ---
 name: update-claude-model
-description: Add a new Claude (Anthropic) model version to pidgin/data/models.json. Use when the user mentions a newly released claude-opus, claude-sonnet, or claude-haiku version (e.g. "opus 4.8 just dropped", "add the new sonnet", "bump haiku").
+description: Add a new Claude (Anthropic) model version to pidgin/data/models.json. Use when the user mentions a newly released claude-fable, claude-opus, claude-sonnet, or claude-haiku version (e.g. "opus 4.8 just dropped", "add the new sonnet", "bump fable", "bump haiku").
 ---
 
 # Update Claude model
 
 Follow the universal recipe in `update-model`, with these Anthropic-specific details.
 
+## Families
+
+Current Anthropic families, top-tier first:
+
+- **fable** — public-facing flagship from the mythos line. 1M context.
+- **opus** — high-capability tier. 1M context (current 4.x).
+- **sonnet** — mid-tier workhorse. 1M context (current 4.x).
+- **haiku** — fast/cheap tier. 200K context (current 4.x).
+
+Notes:
+
+- **Mythos** is a related limited-availability internal line and is **not** registered in `models.json`. Fable is the publicly available mythos-class model. Do not add Mythos entries unless the user explicitly asks.
+
 ## Conventions
 
-- **Key**: `claude-<family>-<MAJOR>.<MINOR>` — e.g. `claude-opus-4.8`, `claude-sonnet-4.7`, `claude-haiku-5.0`.
-- **display_name**: `"Anthropic: Claude <Family> <MAJOR>.<MINOR>"` — e.g. `"Anthropic: Claude Opus 4.8"`.
+- **Key**: `claude-<family>-<MAJOR>.<MINOR>` — e.g. `claude-opus-4.8`, `claude-sonnet-4.7`, `claude-haiku-5.0`. Fable currently ships major-version-only (`claude-fable-5`); if a minor lands, follow the same pattern (`claude-fable-5.1`).
+- **display_name**: `"Anthropic: Claude <Family> <MAJOR>.<MINOR>"` — e.g. `"Anthropic: Claude Opus 4.8"`, `"Anthropic: Claude Fable 5"`.
 - **api.model_id**: matches Anthropic's API id. Two patterns occur:
-  - Dateless: `claude-<family>-<MAJOR>-<MINOR>` (e.g. `claude-opus-4-8`).
+  - Dateless: `claude-<family>-<MAJOR>-<MINOR>` (e.g. `claude-opus-4-8`, `claude-fable-5`).
   - Dated snapshot: `claude-<family>-<MAJOR>-<MINOR>-<YYYYMMDD>` (e.g. `claude-haiku-4-5-20251001`).
   - When the dateless id is available (which is usually the case for the current release), prefer it. Look at the Claude Code environment context block for the canonical id of the model you're running on; older Haiku-style entries may keep their dated snapshot.
-- **Family alias** (`aliases` field): `opus`, `sonnet`, or `haiku`. The newest version in the family owns it; clear the previous owner's `aliases` to `[]`.
+- **Family alias** (`aliases` field): `fable`, `opus`, `sonnet`, or `haiku`. The newest version in the family owns it; clear the previous owner's `aliases` to `[]`.
 
 ## Pricing defaults (per 1M tokens, USD)
 
 | Family | input | output |
 |---|---|---|
+| fable  | `1e-05` | `5e-05`  |
 | opus   | `5e-06` | `2.5e-05` |
 | sonnet | `3e-06` | `1.5e-05` |
 | haiku  | `1e-06` | `5e-06`  |
 
-Use these unless Anthropic has announced a change for the new release.
+Use these unless Anthropic has announced a change for the new release. Always confirm against Anthropic's pricing page if the user provides one.
 
 ## Capabilities & limits
 
-Copy from the previous entry in the same family — do not invent values. As of late Claude 4.x:
+Copy from the previous entry in the same family — do not invent values. As of late Claude 4.x / Fable 5:
 
-- `max_context_tokens`: `1000000` for current Opus/Sonnet, `200000` for current Haiku.
+- `max_context_tokens`: `1000000` for current Fable/Opus/Sonnet, `200000` for current Haiku.
 - `streaming`, `tool_calling`, `system_messages`, `json_mode`: `true`.
 - `vision`, `extended_thinking`, `prompt_caching`: vary by family; copy them verbatim from the previous entry rather than guessing.
 

--- a/.claude/skills/update-claude-model/SKILL.md
+++ b/.claude/skills/update-claude-model/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: update-claude-model
+description: Add a new Claude (Anthropic) model version to pidgin/data/models.json. Use when the user mentions a newly released claude-opus, claude-sonnet, or claude-haiku version (e.g. "opus 4.8 just dropped", "add the new sonnet", "bump haiku").
+---
+
+# Update Claude model
+
+Follow the universal recipe in `update-model`, with these Anthropic-specific details.
+
+## Conventions
+
+- **Key**: `claude-<family>-<MAJOR>.<MINOR>` — e.g. `claude-opus-4.8`, `claude-sonnet-4.7`, `claude-haiku-5.0`.
+- **display_name**: `"Anthropic: Claude <Family> <MAJOR>.<MINOR>"` — e.g. `"Anthropic: Claude Opus 4.8"`.
+- **api.model_id**: matches Anthropic's API id. Two patterns occur:
+  - Dateless: `claude-<family>-<MAJOR>-<MINOR>` (e.g. `claude-opus-4-8`).
+  - Dated snapshot: `claude-<family>-<MAJOR>-<MINOR>-<YYYYMMDD>` (e.g. `claude-haiku-4-5-20251001`).
+  - When the dateless id is available (which is usually the case for the current release), prefer it. Look at the Claude Code environment context block for the canonical id of the model you're running on; older Haiku-style entries may keep their dated snapshot.
+- **Family alias** (`aliases` field): `opus`, `sonnet`, or `haiku`. The newest version in the family owns it; clear the previous owner's `aliases` to `[]`.
+
+## Pricing defaults (per 1M tokens, USD)
+
+| Family | input | output |
+|---|---|---|
+| opus   | `5e-06` | `2.5e-05` |
+| sonnet | `3e-06` | `1.5e-05` |
+| haiku  | `1e-06` | `5e-06`  |
+
+Use these unless Anthropic has announced a change for the new release.
+
+## Capabilities & limits
+
+Copy from the previous entry in the same family — do not invent values. As of late Claude 4.x:
+
+- `max_context_tokens`: `1000000` for current Opus/Sonnet, `200000` for current Haiku.
+- `streaming`, `tool_calling`, `system_messages`, `json_mode`: `true`.
+- `vision`, `extended_thinking`, `prompt_caching`: vary by family; copy them verbatim from the previous entry rather than guessing.
+
+If Anthropic has announced a new capability (e.g. vision newly enabled), update only that flag.
+
+## Recipe
+
+1. Locate the previous latest entry (e.g. `claude-opus-4.7`) in `pidgin/data/models.json`.
+2. Edit its `aliases` array down to `[]`.
+3. Insert the new entry directly after it, cloned from its body, with the bumped key, `display_name`, `api.model_id`, `aliases: ["<family>"]`, and today's `cost.last_updated`.
+4. Validate and commit per the universal recipe in `update-model`.
+
+Commit message format: `chore: add <new-key> and move <family> alias` (e.g. `chore: add claude-opus-4.8 and move opus alias`).

--- a/.claude/skills/update-google-model/SKILL.md
+++ b/.claude/skills/update-google-model/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: update-google-model
+description: Add a new Google model version (Gemini or Gemma) to pidgin/data/models.json. Use when the user mentions a newly released gemini-* (gemini-3.0-pro, gemini-2.5-flash, etc.) or gemma-* model.
+---
+
+# Update Google model
+
+Follow the universal recipe in `update-model`, with these Google-specific details.
+
+## Conventions
+
+- **Key**: the canonical Google model id — e.g. `gemini-3.0-pro`, `gemini-2.5-flash`, `gemma-3-27b-it`.
+- **display_name**: existing entries use the bare id (`"gemini-2.5-pro"`). Match that style.
+- **api.model_id**: equal to the key.
+
+## Family aliases
+
+| Family / tier | Alias |
+|---|---|
+| Latest Gemini Pro     | `gemini` |
+| Latest Gemini Flash   | `flash` |
+| Previous-major Flash  | `flash<MAJOR>` (e.g. `flash2` for `gemini-2.0-flash`) |
+
+When bumping a major Pro or Flash release, move the alias to the new entry and clear the previous owner's `aliases` to `[]`. Gemma models typically have no alias.
+
+## Pricing & limits
+
+Gemini pricing varies (Pro vs Flash). Copy from the closest sibling and flag in the summary so the user can confirm. `max_context_tokens` for current Gemini 2.x sits in the 1M range — copy from the sibling rather than guessing.
+
+## Capabilities
+
+Copy from the closest sibling. Gemini 2.5 Pro and Flash have `vision: true` in the current data.
+
+## Recipe
+
+1. Locate the closest sibling (same tier — Pro/Flash/Gemma variant).
+2. If the new model takes over `gemini` or `flash`, clear that alias from the previous owner.
+3. Insert the new entry cloned from the sibling, with new key, `display_name`, `api.model_id`, appropriate alias(es), and today's `cost.last_updated`.
+4. Validate and commit per `update-model`.
+
+Commit message format: `chore: add <new-key>` (add `and move <alias> alias` if an alias was moved).

--- a/.claude/skills/update-model/SKILL.md
+++ b/.claude/skills/update-model/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: update-model
+description: Add a new model version to pidgin/data/models.json. Use when the user mentions a newly released model from Anthropic (Claude/Opus/Sonnet/Haiku), OpenAI (GPT/o-series), Google (Gemini/Gemma), or xAI (Grok) and wants it registered. Dispatches to the per-provider sub-skill.
+---
+
+# Update Model (meta)
+
+Pidgin tracks every supported model in `pidgin/data/models.json`. Adding a new version follows a uniform recipe with small per-provider differences.
+
+## Dispatch
+
+Identify the provider from the model name and follow the matching sub-skill:
+
+| Family | Provider | Sub-skill |
+|---|---|---|
+| `claude-*`, opus, sonnet, haiku | anthropic | `update-claude-model` |
+| `gpt-*`, `o<N>` (o1/o3/o4/o5...) | openai | `update-openai-model` |
+| `gemini-*`, `gemma-*` | google | `update-google-model` |
+| `grok-*` | xai | `update-xai-model` |
+
+If multiple providers shipped at once, run each sub-skill in turn.
+
+## Universal recipe (shared by every sub-skill)
+
+1. **Find the previous latest entry** for the same family in `pidgin/data/models.json` (e.g. `claude-opus-4.7` when adding 4.8). Use it as the template.
+2. **Insert a new entry** directly after it, cloned from its body, with:
+   - new key (version bumped)
+   - bumped `display_name`
+   - new `api.model_id` (provider's actual id — see sub-skill)
+   - `cost.last_updated` set to today's date
+3. **Move the family alias** (`opus`/`sonnet`/`haiku`/`gemini`/`flash`/`grok`/etc.) from the old entry's `aliases` array to the new entry's. Leave the old entry's metadata otherwise intact.
+4. **Do not modify** sibling entries, capability flags, or pricing unless the sub-skill says to.
+5. **Validate**:
+   ```bash
+   uv run python -c "
+   import json; json.load(open('pidgin/data/models.json'))
+   from pidgin.config.models import resolve_model_id
+   for name in ['<family-alias>', '<new-key>', '<previous-key>']:
+       mid, cfg = resolve_model_id(name)
+       print(f'{name} -> {mid} (api_id: {cfg.api.model_id if cfg else None})')
+   "
+   ```
+   The family alias must resolve to the new key. The old key must still resolve to itself.
+6. **Commit & push** on the active development branch:
+   ```bash
+   git add pidgin/data/models.json
+   git commit -m "chore: add <new-key> and move <family> alias"
+   git push -u origin <branch>
+   ```
+
+## Notes
+
+- `scripts/model_overrides.yaml` is only consulted when `scripts/generate_models.py` is re-run. Hand edits to `models.json` are the supported quick path; the overrides file does not need an entry per release.
+- No PR unless the user asks for one.

--- a/.claude/skills/update-openai-model/SKILL.md
+++ b/.claude/skills/update-openai-model/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: update-openai-model
+description: Add a new OpenAI model version (GPT or o-series) to pidgin/data/models.json. Use when the user mentions a newly released gpt-* (gpt-5, gpt-4.2, etc.) or o-series (o3, o4, o5, mini variants) model.
+---
+
+# Update OpenAI model
+
+Follow the universal recipe in `update-model`, with these OpenAI-specific details.
+
+## Conventions
+
+- **Key**: the canonical OpenAI model id, no prefix — e.g. `gpt-5`, `gpt-4.2`, `o5`, `o4-mini`.
+- **display_name**: same as the key, or whatever OpenAI's display string is (existing entries use the bare id, e.g. `"gpt-4.1"`).
+- **api.model_id**: equal to the key. OpenAI rarely uses dated suffixes for the canonical id; if a dated snapshot is the only available id, use it verbatim.
+
+## Family aliases
+
+These are the short aliases users type:
+
+| Family / model | Alias |
+|---|---|
+| Latest non-mini `gpt-N` | `gpt<N>` (e.g. `gpt5` for `gpt-5`) |
+| Latest `gpt-N-mini`     | `gpt<N>-mini` |
+| Latest `gpt-N-nano`     | `gpt<N>-nano` |
+| Latest non-mini `o<N>`  | `o<N>` |
+| Latest `o<N>-mini`      | `o<N>-mini` |
+| `gpt-4o`                | `4o` |
+| `gpt-4o-mini`           | `4o-mini` |
+
+When bumping a major version, move the alias to the new entry and clear the previous owner's `aliases` to `[]`.
+
+## Pricing & limits
+
+OpenAI pricing varies per model — **do not assume**. If the user provides pricing, use it. Otherwise copy from the closest existing sibling and flag this in the commit/summary so the user can confirm.
+
+`max_context_tokens` and `max_output_tokens`: copy from the closest sibling entry.
+
+## Capabilities
+
+Copy from the closest sibling. Notable defaults seen in the current data:
+
+- o-series: `extended_thinking: true`, `tool_calling: false` (o1 specifically; check the sibling).
+- GPT-4o family: `vision: true`.
+- Other GPTs: `vision: false` unless announced.
+
+## Recipe
+
+1. Locate the closest sibling (same family/tier) in `pidgin/data/models.json`.
+2. If the new model takes over a short alias, clear that alias from the previous owner.
+3. Insert the new entry cloned from the sibling, with new key, `display_name`, `api.model_id`, appropriate alias(es), and today's `cost.last_updated`.
+4. Validate and commit per `update-model`.
+
+Commit message format: `chore: add <new-key>` (add `and move <alias> alias` if an alias was moved).

--- a/.claude/skills/update-xai-model/SKILL.md
+++ b/.claude/skills/update-xai-model/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: update-xai-model
+description: Add a new xAI Grok model version to pidgin/data/models.json. Use when the user mentions a newly released grok-* model.
+---
+
+# Update xAI (Grok) model
+
+Follow the universal recipe in `update-model`, with these xAI-specific details.
+
+## Conventions
+
+- **Key**: the canonical xAI model id — e.g. `grok-5`, `grok-4-mini`.
+- **display_name**: match existing entries (bare id is fine).
+- **api.model_id**: equal to the key.
+
+## Family aliases
+
+| Model | Alias |
+|---|---|
+| Latest non-mini `grok-N` | `grok` |
+| Previous-major non-mini  | `grok<N>` (e.g. `grok3` for `grok-3`) |
+| `*-mini` variants        | typically no alias |
+
+When bumping the latest, move the `grok` alias to the new entry and clear the previous owner's `aliases` to `[]`. Optionally give the demoted previous-latest a `grok<N>` alias if there isn't already one.
+
+## Pricing & limits
+
+xAI doesn't publish via OpenRouter as cleanly as others — these entries were added manually. Copy pricing and limits from the closest sibling and flag in the summary so the user can confirm.
+
+## Capabilities
+
+Copy from the closest sibling.
+
+## Recipe
+
+1. Locate the closest sibling (e.g. `grok-4` when adding `grok-5`).
+2. Clear `["grok"]` from the previous owner's `aliases`.
+3. Insert the new entry cloned from the sibling, with new key, `display_name`, `api.model_id`, `aliases: ["grok"]`, and today's `cost.last_updated`.
+4. Validate and commit per `update-model`.
+
+Commit message format: `chore: add <new-key> and move grok alias`.

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,8 @@ logs/
 
 # IDE & OS
 .DS_Store
-.claude/
+.claude/*
+!.claude/skills/
 
 # Environment
 .env

--- a/pidgin/data/models.json
+++ b/pidgin/data/models.json
@@ -277,6 +277,75 @@
       },
       "rate_limits": null
     },
+    "claude-fable-5": {
+      "provider": "anthropic",
+      "display_name": "Anthropic: Claude Fable 5",
+      "aliases": [
+        "fable"
+      ],
+      "api": {
+        "model_id": "claude-fable-5"
+      },
+      "capabilities": {
+        "streaming": true,
+        "vision": false,
+        "tool_calling": true,
+        "system_messages": true,
+        "extended_thinking": false,
+        "json_mode": true,
+        "prompt_caching": false
+      },
+      "limits": {
+        "max_context_tokens": 1000000,
+        "max_output_tokens": null,
+        "max_thinking_tokens": null
+      },
+      "parameters": {
+        "temperature": {
+          "supported": true,
+          "range": [
+            0.0,
+            1.0
+          ],
+          "default": 0.7
+        },
+        "top_p": {
+          "supported": true,
+          "range": [
+            0.0,
+            1.0
+          ],
+          "default": null
+        },
+        "top_k": {
+          "supported": true,
+          "range": [
+            1,
+            100
+          ],
+          "default": null
+        }
+      },
+      "cost": {
+        "input_per_1m_tokens": 1e-05,
+        "output_per_1m_tokens": 5e-05,
+        "cache_read_per_1m_tokens": null,
+        "cache_write_per_1m_tokens": null,
+        "currency": "USD",
+        "last_updated": "2026-06-10"
+      },
+      "metadata": {
+        "status": "available",
+        "release_date": null,
+        "deprecation_date": null,
+        "curated": false,
+        "stable": true,
+        "description": "",
+        "notes": "",
+        "size": ""
+      },
+      "rate_limits": null
+    },
     "claude-haiku-4.5": {
       "provider": "anthropic",
       "display_name": "Anthropic: Claude Haiku 4.5",

--- a/pidgin/data/models.json
+++ b/pidgin/data/models.json
@@ -617,9 +617,7 @@
     "claude-opus-4.7": {
       "provider": "anthropic",
       "display_name": "Anthropic: Claude Opus 4.7",
-      "aliases": [
-        "opus"
-      ],
+      "aliases": [],
       "api": {
         "model_id": "claude-opus-4-7"
       },
@@ -670,6 +668,75 @@
         "cache_write_per_1m_tokens": null,
         "currency": "USD",
         "last_updated": "2026-04-17"
+      },
+      "metadata": {
+        "status": "available",
+        "release_date": null,
+        "deprecation_date": null,
+        "curated": false,
+        "stable": true,
+        "description": "",
+        "notes": "",
+        "size": ""
+      },
+      "rate_limits": null
+    },
+    "claude-opus-4.8": {
+      "provider": "anthropic",
+      "display_name": "Anthropic: Claude Opus 4.8",
+      "aliases": [
+        "opus"
+      ],
+      "api": {
+        "model_id": "claude-opus-4-8"
+      },
+      "capabilities": {
+        "streaming": true,
+        "vision": false,
+        "tool_calling": true,
+        "system_messages": true,
+        "extended_thinking": false,
+        "json_mode": true,
+        "prompt_caching": false
+      },
+      "limits": {
+        "max_context_tokens": 1000000,
+        "max_output_tokens": null,
+        "max_thinking_tokens": null
+      },
+      "parameters": {
+        "temperature": {
+          "supported": true,
+          "range": [
+            0.0,
+            1.0
+          ],
+          "default": 0.7
+        },
+        "top_p": {
+          "supported": true,
+          "range": [
+            0.0,
+            1.0
+          ],
+          "default": null
+        },
+        "top_k": {
+          "supported": true,
+          "range": [
+            1,
+            100
+          ],
+          "default": null
+        }
+      },
+      "cost": {
+        "input_per_1m_tokens": 5e-06,
+        "output_per_1m_tokens": 2.5e-05,
+        "cache_read_per_1m_tokens": null,
+        "cache_write_per_1m_tokens": null,
+        "currency": "USD",
+        "last_updated": "2026-06-05"
       },
       "metadata": {
         "status": "available",


### PR DESCRIPTION
## Summary

- **`claude-opus-4.8`** added; `opus` alias moved from 4.7 → 4.8. Pricing matches Opus tier ($5/$25 per MTok).
- **`claude-fable-5`** added — new public-facing flagship from the mythos line. `fable` alias assigned. 1M context, $10/$50 per MTok.
- **Per-provider model-update skills** added under `.claude/skills/`:
  - `update-model` (meta dispatcher with universal recipe)
  - `update-claude-model`, `update-openai-model`, `update-google-model`, `update-xai-model`
  - `.gitignore` carved out to track `.claude/skills/` while keeping `settings.local.json` etc. private.
- The Claude skill now documents the **fable** family and notes that Mythos is internal-only and should not be registered.

## Test plan

- [x] `pidgin/data/models.json` parses as valid JSON.
- [x] `resolve_model_id('opus')` → `claude-opus-4.8` (api `claude-opus-4-8`).
- [x] `resolve_model_id('fable')` → `claude-fable-5` (api `claude-fable-5`).
- [x] `resolve_model_id('sonnet')` / `('haiku')` still resolve to their existing latest entries.
- [x] Full test suite passes locally (`uv run pytest`, 50 passed).
- [ ] CI on this PR.

https://claude.ai/code/session_01R6yPcBMWFF8F3cEeCLWQ41

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6yPcBMWFF8F3cEeCLWQ41)_