### PR TITLE
Fix response truncation and empty-response cascade

### DIFF
--- a/pidgin/cli/config_builder.py
+++ b/pidgin/cli/config_builder.py
@@ -49,6 +49,7 @@ class ConfigBuilder:
         think_a: bool = False,
         think_b: bool = False,
         think_budget: Optional[int] = None,
+        max_tokens: Optional[int] = None,
     ) -> Tuple[ExperimentConfig, str, str]:
         """Build experiment configuration from CLI arguments.
 
@@ -112,6 +113,7 @@ class ConfigBuilder:
             think_a=think_a,
             think_b=think_b,
             think_budget=think_budget,
+            max_tokens=max_tokens,
             custom_prompt=initial_prompt,
             max_parallel=max_parallel,
             convergence_threshold=final_convergence_threshold,

--- a/pidgin/cli/run.py
+++ b/pidgin/cli/run.py
@@ -58,6 +58,12 @@ console = Console()
     default=None,
     help="Max thinking tokens (default: 10000)",
 )
+@click.option(
+    "--max-tokens",
+    type=click.IntRange(1, 100000),
+    default=None,
+    help="Max response tokens per turn (default: 8192)",
+)
 @click.option("--output", "-o", help="Custom output directory")
 @click.option(
     "--convergence-threshold",
@@ -137,6 +143,7 @@ def run(
     think_a: bool,
     think_b: bool,
     think_budget: Optional[int],
+    max_tokens: Optional[int],
     output: Optional[str],
     convergence_threshold: Optional[float],
     convergence_action: Optional[str],
@@ -182,6 +189,7 @@ def run(
         think_a=think_a,
         think_b=think_b,
         think_budget=think_budget,
+        max_tokens=max_tokens,
         output=output,
         convergence_threshold=convergence_threshold,
         convergence_action=convergence_action,

--- a/pidgin/cli/run_handlers/command_handler.py
+++ b/pidgin/cli/run_handlers/command_handler.py
@@ -88,6 +88,7 @@ class CommandHandler:
             think_a=config.agents.think_a,
             think_b=config.agents.think_b,
             think_budget=config.agents.think_budget,
+            max_tokens=config.agents.max_tokens,
             prompt=config.conversation.prompt,
             name=config.execution.name,
             convergence_threshold=config.convergence.convergence_threshold,

--- a/pidgin/cli/run_handlers/models.py
+++ b/pidgin/cli/run_handlers/models.py
@@ -20,6 +20,7 @@ class AgentConfig:
     think_a: bool = False
     think_b: bool = False
     think_budget: Optional[int] = None
+    max_tokens: Optional[int] = None
 
 
 @dataclass
@@ -98,6 +99,7 @@ class RunConfig:
                 think_a=kwargs.get("think_a", False),
                 think_b=kwargs.get("think_b", False),
                 think_budget=kwargs.get("think_budget"),
+                max_tokens=kwargs.get("max_tokens"),
             ),
             conversation=ConversationConfig(
                 prompt=kwargs.get("prompt"),

--- a/pidgin/cli/spec_loader.py
+++ b/pidgin/cli/spec_loader.py
@@ -125,6 +125,7 @@ class SpecLoader:
         display_mode = spec.get("display_mode", "chat")
         prompt_tag = spec.get("prompt_tag", "[HUMAN]")
         allow_truncation = spec.get("allow_truncation", False)
+        max_tokens = spec.get("max_tokens")
 
         return ExperimentConfig(
             name=name,
@@ -145,6 +146,7 @@ class SpecLoader:
             display_mode=display_mode,
             prompt_tag=prompt_tag,
             allow_truncation=allow_truncation,
+            max_tokens=max_tokens,
         )
 
     def show_spec_info(self, spec_file: Path, config: ExperimentConfig) -> None:

--- a/pidgin/core/conductor.py
+++ b/pidgin/core/conductor.py
@@ -249,10 +249,13 @@ class Conductor:
             MessageCompleteEvent, self.message_handler.handle_message_complete
         )
 
-        # Subscribe to context limit events
-        from .events import ContextLimitEvent
+        # Subscribe to conversation-ending provider events
+        from .events import ContextLimitEvent, EmptyResponseEvent
 
         self.bus.subscribe(ContextLimitEvent, self.message_handler.handle_context_limit)
+        self.bus.subscribe(
+            EmptyResponseEvent, self.message_handler.handle_empty_response
+        )
 
     async def _initialize_conversation(
         self,

--- a/pidgin/core/constants.py
+++ b/pidgin/core/constants.py
@@ -13,6 +13,7 @@ class EndReason:
     HIGH_CONVERGENCE = "high_convergence"
     INTERRUPTED = "interrupted"
     CONTEXT_LIMIT_REACHED = "context_limit_reached"
+    EMPTY_RESPONSE = "empty_response"
     MAX_TURNS = "max_turns"
     ERROR = "error"
     MAX_TURNS_REACHED = "max_turns_reached"

--- a/pidgin/core/events.py
+++ b/pidgin/core/events.py
@@ -56,6 +56,7 @@ class MessageRequestEvent(Event):
     allow_truncation: bool = False
     thinking_enabled: Optional[bool] = None
     thinking_budget: Optional[int] = None
+    max_tokens: Optional[int] = None
 
 
 @dataclass

--- a/pidgin/core/events.py
+++ b/pidgin/core/events.py
@@ -258,6 +258,20 @@ class ContextLimitEvent(Event):
 
 
 @dataclass
+class EmptyResponseEvent(Event):
+    """Emitted when a provider returns an empty response, ending the conversation.
+
+    An empty assistant turn cannot be replayed as the other agent's user
+    message, so the conversation ends here rather than poisoning later turns.
+    """
+
+    conversation_id: str
+    agent_id: str
+    turn_number: int
+    provider: str
+
+
+@dataclass
 class ConversationBranchedEvent(Event):
     """Emitted when a conversation is branched from another."""
 

--- a/pidgin/core/message_handler.py
+++ b/pidgin/core/message_handler.py
@@ -177,6 +177,7 @@ class MessageHandler:
                 temperature=agent.temperature,
                 thinking_enabled=agent.thinking_enabled,
                 thinking_budget=agent.thinking_budget,
+                max_tokens=agent.max_tokens,
             )
         )
 

--- a/pidgin/core/message_handler.py
+++ b/pidgin/core/message_handler.py
@@ -150,10 +150,10 @@ class MessageHandler:
                 conversation_id, agent, turn_number, timeout, future
             )
         except Exception as e:
-            # Check if this is a context limit error
-            from ..providers.error_utils import ContextLimitError
+            # Check if this is a clean conversation-ending condition
+            from ..providers.error_utils import ContextLimitError, EmptyResponseError
 
-            if isinstance(e, ContextLimitError):
+            if isinstance(e, (ContextLimitError, EmptyResponseError)):
                 # Return None to signal the conversation should end
                 return None
             else:
@@ -319,6 +319,25 @@ class MessageHandler:
                 from ..providers.error_utils import ContextLimitError
 
                 future.set_exception(ContextLimitError(event.error_message))
+
+    async def handle_empty_response(self, event):
+        """Handle empty response event by failing the pending message.
+
+        Args:
+            event: EmptyResponseEvent
+        """
+        # Set exception in the pending future for this agent
+        if event.agent_id in self.pending_messages:
+            future = self.pending_messages.pop(event.agent_id)
+            if not future.done():
+                from ..providers.error_utils import EmptyResponseError
+
+                future.set_exception(
+                    EmptyResponseError(
+                        f"Empty response from {event.provider} "
+                        f"(agent {event.agent_id}, turn {event.turn_number})"
+                    )
+                )
 
     def _estimate_payload_tokens(
         self, conversation_history: List[Message], model: str

--- a/pidgin/core/turn_executor.py
+++ b/pidgin/core/turn_executor.py
@@ -44,11 +44,12 @@ class TurnExecutor:
         # Custom awareness for turn-based prompt injection
         self.custom_awareness = {"agent_a": None, "agent_b": None}
 
-        # Subscribe to context limit events
+        # Subscribe to conversation-ending provider events
         if bus:
-            from .events import ContextLimitEvent
+            from .events import ContextLimitEvent, EmptyResponseEvent
 
             bus.subscribe(ContextLimitEvent, self.handle_context_limit)
+            bus.subscribe(EmptyResponseEvent, self.handle_empty_response)
 
     def set_convergence_overrides(self, threshold=None, action=None):
         """Set convergence threshold and action overrides.
@@ -238,3 +239,11 @@ class TurnExecutor:
         """
         self.context_limit_reached = True
         self.stop_reason = EndReason.CONTEXT_LIMIT_REACHED
+
+    async def handle_empty_response(self, event):
+        """Handle empty response event by recording the stop reason.
+
+        Args:
+            event: EmptyResponseEvent
+        """
+        self.stop_reason = EndReason.EMPTY_RESPONSE

--- a/pidgin/core/types.py
+++ b/pidgin/core/types.py
@@ -116,6 +116,7 @@ class Agent(BaseModel):
     temperature: Optional[float] = None  # Temperature setting for this agent
     thinking_enabled: Optional[bool] = None  # Enable extended thinking for this agent
     thinking_budget: Optional[int] = None  # Max thinking tokens for this agent
+    max_tokens: Optional[int] = None  # Max response tokens (None -> provider default)
 
 
 class Conversation(BaseModel):

--- a/pidgin/experiments/config.py
+++ b/pidgin/experiments/config.py
@@ -33,6 +33,9 @@ class ExperimentConfig:
     think_b: bool = False  # Override for agent B
     think_budget: Optional[int] = None  # Max thinking tokens (default: 10000)
 
+    # Response length cap (matching CLI)
+    max_tokens: Optional[int] = None  # Max response tokens (None -> provider default)
+
     # Awareness levels (matching CLI)
     awareness: str = "basic"  # Default for both agents
     awareness_a: Optional[str] = None  # Override for agent A

--- a/pidgin/experiments/experiment_setup.py
+++ b/pidgin/experiments/experiment_setup.py
@@ -140,6 +140,7 @@ class ExperimentSetup:
             display_name=model_a_config.display_name,  # Use the model's display name
             thinking_enabled=thinking_a if thinking_a else None,
             thinking_budget=config.think_budget if thinking_a else None,
+            max_tokens=config.max_tokens,
         )
 
         agent_b = Agent(
@@ -150,6 +151,7 @@ class ExperimentSetup:
             display_name=model_b_config.display_name,  # Use the model's display name
             thinking_enabled=thinking_b if thinking_b else None,
             thinking_budget=config.think_budget if thinking_b else None,
+            max_tokens=config.max_tokens,
         )
 
         agents = {"agent_a": agent_a, "agent_b": agent_b}

--- a/pidgin/providers/anthropic.py
+++ b/pidgin/providers/anthropic.py
@@ -6,7 +6,7 @@ from anthropic import AsyncAnthropic
 
 from ..core.types import Message
 from .api_key_manager import APIKeyManager
-from .base import Provider, ResponseChunk
+from .base import DEFAULT_MAX_TOKENS, Provider, ResponseChunk
 from .error_utils import create_anthropic_error_handler
 from .retry_utils import retry_with_exponential_backoff
 
@@ -29,6 +29,7 @@ class AnthropicProvider(Provider):
         temperature: Optional[float] = None,
         thinking_enabled: Optional[bool] = None,
         thinking_budget: Optional[int] = None,
+        max_tokens: Optional[int] = None,
     ) -> AsyncGenerator[ResponseChunk, None]:
         # Apply context truncation
         from .context_utils import (
@@ -53,7 +54,11 @@ class AnthropicProvider(Provider):
         api_params: Dict[str, Any] = {
             "model": self.model,
             "messages": conversation_messages,
-            "max_tokens": 16000 if thinking_enabled else 1000,
+            # Explicit max_tokens wins; otherwise extended thinking needs extra
+            # headroom for the reasoning trace, plain responses use the default.
+            "max_tokens": max_tokens
+            if max_tokens is not None
+            else (16000 if thinking_enabled else DEFAULT_MAX_TOKENS),
         }
 
         # Add temperature if specified (Anthropic caps at 1.0)

--- a/pidgin/providers/base.py
+++ b/pidgin/providers/base.py
@@ -7,6 +7,12 @@ from typing import Dict, List, Literal, Optional
 
 from ..core.types import Message
 
+# Default ceiling on response (completion) tokens when an agent does not
+# specify one. Chosen to be large enough that normal conversational turns are
+# never truncated mid-sentence; providers may override for special modes
+# (e.g. Anthropic extended thinking needs more headroom).
+DEFAULT_MAX_TOKENS = 8192
+
 
 @dataclass
 class ResponseChunk:
@@ -47,6 +53,7 @@ class Provider(ABC):
         temperature: Optional[float] = None,
         thinking_enabled: Optional[bool] = None,
         thinking_budget: Optional[int] = None,
+        max_tokens: Optional[int] = None,
     ) -> AsyncGenerator[ResponseChunk, None]:
         """Stream response chunks from the model.
 
@@ -63,6 +70,9 @@ class Provider(ABC):
                             Only supported by some models (e.g., Claude 3.5+).
             thinking_budget: Optional maximum tokens for thinking (default: 10000).
                            Only applies when thinking_enabled is True.
+            max_tokens: Optional ceiling on response (completion) tokens. When
+                       None, providers fall back to DEFAULT_MAX_TOKENS. This
+                       bounds the visible reply, not the thinking budget.
 
         Yields:
             ResponseChunk: Chunks of the response with type annotation.

--- a/pidgin/providers/error_utils.py
+++ b/pidgin/providers/error_utils.py
@@ -9,6 +9,17 @@ class ContextLimitError(Exception):
     pass
 
 
+class EmptyResponseError(Exception):
+    """Raised when a provider returns an empty (or whitespace-only) response.
+
+    An empty assistant turn cannot be replayed as the other agent's user
+    message (APIs reject empty content), so it ends the conversation cleanly
+    rather than poisoning every subsequent turn.
+    """
+
+    pass
+
+
 class ErrorClassifier:
     """Classify different types of errors."""
 

--- a/pidgin/providers/event_wrapper.py
+++ b/pidgin/providers/event_wrapper.py
@@ -7,6 +7,7 @@ import time
 from ..core.event_bus import EventBus
 from ..core.events import (
     APIErrorEvent,
+    EmptyResponseEvent,
     MessageCompleteEvent,
     MessageRequestEvent,
     ThinkingCompleteEvent,
@@ -150,6 +151,30 @@ class EventAwareProvider:
 
             # Build complete message
             content = "".join(response_chunks)
+
+            # Guard against empty responses. An empty (or whitespace-only)
+            # assistant turn cannot be replayed as the other agent's user
+            # message — APIs reject empty content, which otherwise poisons every
+            # subsequent turn. End the conversation cleanly with a recorded
+            # reason instead of emitting an unusable message.
+            if not content.strip():
+                provider_name = self.provider.__class__.__name__.replace("Provider", "")
+                logger.warning(
+                    "Empty response from %s (agent %s, turn %s); ending conversation",
+                    provider_name,
+                    self.agent_id,
+                    event.turn_number,
+                )
+                await self.bus.emit(
+                    EmptyResponseEvent(
+                        conversation_id=event.conversation_id,
+                        agent_id=self.agent_id,
+                        turn_number=event.turn_number,
+                        provider=provider_name,
+                    )
+                )
+                return
+
             message = Message(
                 role="assistant",
                 content=content,

--- a/pidgin/providers/event_wrapper.py
+++ b/pidgin/providers/event_wrapper.py
@@ -98,6 +98,7 @@ class EventAwareProvider:
                         temperature=event.temperature,
                         thinking_enabled=event.thinking_enabled,
                         thinking_budget=event.thinking_budget,
+                        max_tokens=event.max_tokens,
                     ):
                         # Handle ResponseChunk objects
                         if isinstance(chunk, ResponseChunk):

--- a/pidgin/providers/google.py
+++ b/pidgin/providers/google.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional
 
 from ..core.types import Message
 from .api_key_manager import APIKeyManager
-from .base import Provider, ResponseChunk
+from .base import DEFAULT_MAX_TOKENS, Provider, ResponseChunk
 from .error_utils import create_google_error_handler
 
 logger = logging.getLogger(__name__)
@@ -39,6 +39,7 @@ class GoogleProvider(Provider):
         temperature: Optional[float] = None,
         thinking_enabled: Optional[bool] = None,
         thinking_budget: Optional[int] = None,
+        max_tokens: Optional[int] = None,
     ) -> AsyncGenerator[ResponseChunk, None]:
         # Apply context truncation
         from .context_utils import apply_context_truncation
@@ -72,7 +73,9 @@ class GoogleProvider(Provider):
         for attempt in range(max_retries):
             try:
                 # Build config with optional temperature and thinking settings
-                config_kwargs: Dict[str, Any] = {}
+                config_kwargs: Dict[str, Any] = {
+                    "max_output_tokens": max_tokens or DEFAULT_MAX_TOKENS,
+                }
                 if temperature is not None:
                     config_kwargs["temperature"] = temperature
 

--- a/pidgin/providers/local.py
+++ b/pidgin/providers/local.py
@@ -21,9 +21,11 @@ class LocalProvider(Provider):
         temperature: Optional[float] = None,
         thinking_enabled: Optional[bool] = None,
         thinking_budget: Optional[int] = None,
+        max_tokens: Optional[int] = None,
     ) -> AsyncGenerator[ResponseChunk, None]:
         """Stream response from test model."""
-        # Note: thinking_enabled and thinking_budget are not supported by local
+        # Note: thinking_enabled, thinking_budget, and max_tokens are not
+        # supported by local
         if self.model_name != "test":
             yield ResponseChunk(
                 f"Error: LocalProvider only supports 'test' model. Got: {self.model_name}",

--- a/pidgin/providers/ollama.py
+++ b/pidgin/providers/ollama.py
@@ -4,12 +4,12 @@ import json
 import logging
 import socket
 from collections.abc import AsyncGenerator
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 import aiohttp
 
 from ..core.types import Message
-from .base import Provider, ResponseChunk
+from .base import DEFAULT_MAX_TOKENS, Provider, ResponseChunk
 from .error_utils import ProviderErrorHandler
 
 logger = logging.getLogger(__name__)
@@ -65,6 +65,7 @@ class OllamaProvider(Provider):
         temperature: Optional[float] = None,
         thinking_enabled: Optional[bool] = None,
         thinking_budget: Optional[int] = None,
+        max_tokens: Optional[int] = None,
     ) -> AsyncGenerator[ResponseChunk, None]:
         """Stream response from Ollama model."""
         # Note: thinking_enabled and thinking_budget are not supported by Ollama
@@ -100,8 +101,10 @@ class OllamaProvider(Provider):
             "stream": True,
         }
 
+        options: Dict[str, Any] = {"num_predict": max_tokens or DEFAULT_MAX_TOKENS}
         if temperature is not None:
-            request_data["options"] = {"temperature": temperature}
+            options["temperature"] = temperature
+        request_data["options"] = options
 
         # Configure timeouts for local model
         timeout = aiohttp.ClientTimeout(

--- a/pidgin/providers/openai.py
+++ b/pidgin/providers/openai.py
@@ -6,7 +6,7 @@ from openai import AsyncOpenAI
 
 from ..core.types import Message
 from .api_key_manager import APIKeyManager
-from .base import Provider, ResponseChunk
+from .base import DEFAULT_MAX_TOKENS, Provider, ResponseChunk
 from .error_utils import create_openai_error_handler
 from .retry_utils import retry_with_exponential_backoff
 
@@ -29,6 +29,7 @@ class OpenAIProvider(Provider):
         temperature: Optional[float] = None,
         thinking_enabled: Optional[bool] = None,
         thinking_budget: Optional[int] = None,
+        max_tokens: Optional[int] = None,
     ) -> AsyncGenerator[ResponseChunk, None]:
         # Note: OpenAI doesn't expose reasoning traces in their API
         # thinking_enabled and thinking_budget are accepted but ignored
@@ -54,7 +55,7 @@ class OpenAIProvider(Provider):
             params = {
                 "model": self.model,
                 "messages": openai_messages,
-                "max_completion_tokens": 1000,
+                "max_completion_tokens": max_tokens or DEFAULT_MAX_TOKENS,
                 "stream": True,
                 "stream_options": {"include_usage": True},  # Request usage data
             }

--- a/pidgin/providers/silent.py
+++ b/pidgin/providers/silent.py
@@ -26,6 +26,7 @@ class SilentProvider(Provider):
         temperature: Optional[float] = None,
         thinking_enabled: Optional[bool] = None,
         thinking_budget: Optional[int] = None,
+        max_tokens: Optional[int] = None,
     ) -> AsyncGenerator[ResponseChunk, None]:
         """Return empty response - pure silence.
 

--- a/pidgin/providers/test_model.py
+++ b/pidgin/providers/test_model.py
@@ -54,6 +54,7 @@ class LocalTestModel(Provider):
         temperature: Optional[float] = None,
         thinking_enabled: Optional[bool] = None,
         thinking_budget: Optional[int] = None,
+        max_tokens: Optional[int] = None,
     ) -> AsyncGenerator[ResponseChunk, None]:
         """Stream response chunks from the model.
 

--- a/pidgin/providers/xai.py
+++ b/pidgin/providers/xai.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional
 
 from ..core.types import Message
 from .api_key_manager import APIKeyManager
-from .base import Provider, ResponseChunk
+from .base import DEFAULT_MAX_TOKENS, Provider, ResponseChunk
 from .retry_utils import retry_with_exponential_backoff
 
 logger = logging.getLogger(__name__)
@@ -43,6 +43,7 @@ class xAIProvider(Provider):
         temperature: Optional[float] = None,
         thinking_enabled: Optional[bool] = None,
         thinking_budget: Optional[int] = None,
+        max_tokens: Optional[int] = None,
     ) -> AsyncGenerator[ResponseChunk, None]:
         # Note: thinking_enabled and thinking_budget are not supported by xAI
         # Apply context truncation
@@ -67,7 +68,7 @@ class xAIProvider(Provider):
             params = {
                 "model": self.model,
                 "messages": openai_messages,
-                "max_tokens": 1000,
+                "max_tokens": max_tokens or DEFAULT_MAX_TOKENS,
                 "stream": True,
                 "stream_options": {
                     "include_usage": True

--- a/pidgin/ui/display_filter.py
+++ b/pidgin/ui/display_filter.py
@@ -10,6 +10,7 @@ from ..core.events import (
     ConversationEndEvent,
     ConversationResumedEvent,
     ConversationStartEvent,
+    EmptyResponseEvent,
     ErrorEvent,
     Event,
     MessageCompleteEvent,
@@ -121,6 +122,8 @@ class DisplayFilter:
                 self.error_handler.show_error(event)
             elif isinstance(event, ContextLimitEvent):
                 self.error_handler.show_context_limit(event)
+            elif isinstance(event, EmptyResponseEvent):
+                self.error_handler.show_empty_response(event)
             elif isinstance(event, ConversationEndEvent):
                 self.conversation_handler.show_conversation_end(event)
             elif isinstance(event, ConversationResumedEvent):

--- a/pidgin/ui/display_handlers/errors.py
+++ b/pidgin/ui/display_handlers/errors.py
@@ -5,6 +5,7 @@ from rich.panel import Panel
 from ...core.events import (
     APIErrorEvent,
     ContextLimitEvent,
+    EmptyResponseEvent,
     ErrorEvent,
     ProviderTimeoutEvent,
 )
@@ -169,6 +170,41 @@ class ErrorDisplayHandler(BaseDisplayHandler):
         )
 
         # Calculate appropriate width
+        width = self.calculate_panel_width(content, title)
+
+        self.console.print()
+        self.console.print(
+            Panel(
+                content,
+                title=title,
+                title_align="left",
+                border_style=border_style,
+                padding=(1, 2),
+                width=width,
+                expand=False,
+            )
+        )
+        self.console.print()
+
+    def show_empty_response(self, event: EmptyResponseEvent):
+        """Show that the conversation ended on an empty provider response."""
+        agent_name = None
+        if event.agent_id in self.agents:
+            agent_name = self.agents[event.agent_id].display_name or event.agent_id
+
+        title = "◆ Empty Response"
+        border_style = self.COLORS["nord13"]  # Yellow
+
+        content = (
+            f"[bold {self.COLORS['nord13']}]Conversation Ended[/bold {self.COLORS['nord13']}]\n\n"
+            f"◈ Agent: {agent_name or event.agent_id}\n"
+            f"◈ Provider: {event.provider}\n"
+            f"◈ Turn: {event.turn_number}\n\n"
+            f"[{self.COLORS['nord4']}]The model returned an empty response. An empty turn cannot\n"
+            f"be replayed as the other agent's message, so the conversation\n"
+            f"ends here rather than continuing with an invalid turn.[/{self.COLORS['nord4']}]"
+        )
+
         width = self.calculate_panel_width(content, title)
 
         self.console.print()


### PR DESCRIPTION
## Summary

Two related fixes to a conversation-poisoning failure mode found in the latest logs (the `woven-grid` Fable 5 run collapsed into 23 consecutive API errors).

### 1. Response truncation — `max_tokens` was hardcoded to 1000
`anthropic`, `openai`, and `xai` providers each hardcoded the response cap to **1000 tokens**, silently truncating turns mid-sentence; `google` and `ollama` set no cap at all. `max_tokens` is now a real parameter threaded through the same path as `thinking_budget` (`Agent` → `MessageRequestEvent` → provider), with a shared `DEFAULT_MAX_TOKENS = 8192`, a `--max-tokens` CLI flag, and YAML-spec support. Explicit values win; Anthropic still gets extra headroom under extended thinking.

### 2. Empty-response cascade
An empty (or whitespace-only) assistant turn was emitted as a normal message, then replayed as the other agent's `user` message — which the APIs reject as empty content, 400-ing every subsequent turn. A guard in `event_wrapper` now emits an `EmptyResponseEvent` instead, ending the conversation cleanly with a recorded reason (`EndReason.EMPTY_RESPONSE`, status `completed`), mirroring the existing context-limit path. The event is persisted to JSONL and surfaced in the live UI. No data is fabricated — consistent with the "record, don't interpret" philosophy.

## Testing
- Full suite: 45/45 passing.
- Direct param-resolution check: `None→8192`, explicit wins, thinking→16000.
- Integration test through the real `EventAwareProvider`: empty & whitespace-only → `EmptyResponseEvent` only (no poisoning `MessageCompleteEvent`); normal → `MessageCompleteEvent`.
- Pre-commit (ruff, ruff-format, mypy) clean on both commits.