### PR TITLE
add Vercel AI Gateway provider with Opus 4, Sonnet 4, Kimi K2, GLM 4.6

### DIFF
--- a/pidgin/cli/constants.py
+++ b/pidgin/cli/constants.py
@@ -64,6 +64,7 @@ PROVIDER_COLORS = {
     "anthropic": NORD_ORANGE,
     "google": NORD_BLUE,
     "xai": NORD_PURPLE,
+    "vercel": NORD_CYAN,
     "local": NORD_YELLOW,
 }
 

--- a/pidgin/config/model_types.py
+++ b/pidgin/config/model_types.py
@@ -94,7 +94,7 @@ class RateLimits:
 
 
 ProviderType = Literal[
-    "anthropic", "openai", "google", "xai", "ollama", "local", "silent"
+    "anthropic", "openai", "google", "xai", "vercel", "ollama", "local", "silent"
 ]
 
 

--- a/pidgin/config/provider_capabilities.py
+++ b/pidgin/config/provider_capabilities.py
@@ -50,6 +50,14 @@ PROVIDER_CAPABILITIES: Dict[str, ProviderCapabilities] = {
         supports_tool_use=False,
         supports_vision=False,
     ),
+    "vercel": ProviderCapabilities(
+        requests_per_minute=60,
+        tokens_per_minute=60000,
+        system_prompt_overhead=100,
+        supports_streaming=True,
+        supports_tool_use=False,
+        supports_vision=False,
+    ),
     "local": ProviderCapabilities(
         requests_per_minute=999999,  # No practical limits for local models
         tokens_per_minute=999999,

--- a/pidgin/core/constants.py
+++ b/pidgin/core/constants.py
@@ -89,6 +89,7 @@ class ProviderNames:
     OPENAI = "openai"
     GOOGLE = "google"
     XAI = "xai"
+    VERCEL = "vercel"
     OLLAMA = "ollama"
     LOCAL = "local"
     SILENT = "silent"
@@ -101,3 +102,4 @@ class EnvVars:
     GEMINI_API_KEY = "GEMINI_API_KEY"
     XAI_API_KEY = "XAI_API_KEY"
     GROK_API_KEY = "GROK_API_KEY"
+    AI_GATEWAY_API_KEY = "AI_GATEWAY_API_KEY"

--- a/pidgin/data/models.json
+++ b/pidgin/data/models.json
@@ -614,6 +614,278 @@
       },
       "rate_limits": null
     },
+    "vercel-claude-opus-4": {
+      "provider": "vercel",
+      "display_name": "Vercel: Claude Opus 4",
+      "aliases": [
+        "v-opus-4"
+      ],
+      "api": {
+        "model_id": "anthropic/claude-opus-4"
+      },
+      "capabilities": {
+        "streaming": true,
+        "vision": true,
+        "tool_calling": true,
+        "system_messages": true,
+        "extended_thinking": false,
+        "json_mode": true,
+        "prompt_caching": false
+      },
+      "limits": {
+        "max_context_tokens": 200000,
+        "max_output_tokens": 32000,
+        "max_thinking_tokens": null
+      },
+      "parameters": {
+        "temperature": {
+          "supported": true,
+          "range": [
+            0.0,
+            1.0
+          ],
+          "default": 0.7
+        },
+        "top_p": {
+          "supported": true,
+          "range": [
+            0.0,
+            1.0
+          ],
+          "default": null
+        },
+        "top_k": {
+          "supported": true,
+          "range": [
+            1,
+            100
+          ],
+          "default": null
+        }
+      },
+      "cost": {
+        "input_per_1m_tokens": 1.5e-05,
+        "output_per_1m_tokens": 7.5e-05,
+        "cache_read_per_1m_tokens": null,
+        "cache_write_per_1m_tokens": null,
+        "currency": "USD",
+        "last_updated": "2026-06-15"
+      },
+      "metadata": {
+        "status": "available",
+        "release_date": "2025-05-22",
+        "deprecation_date": null,
+        "curated": true,
+        "stable": true,
+        "description": "",
+        "notes": "Routed via the Vercel AI Gateway (anthropic/claude-opus-4). Retired on Anthropic's native API.",
+        "size": ""
+      },
+      "rate_limits": null
+    },
+    "vercel-claude-sonnet-4": {
+      "provider": "vercel",
+      "display_name": "Vercel: Claude Sonnet 4",
+      "aliases": [
+        "v-sonnet-4"
+      ],
+      "api": {
+        "model_id": "anthropic/claude-sonnet-4"
+      },
+      "capabilities": {
+        "streaming": true,
+        "vision": true,
+        "tool_calling": true,
+        "system_messages": true,
+        "extended_thinking": false,
+        "json_mode": true,
+        "prompt_caching": false
+      },
+      "limits": {
+        "max_context_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_thinking_tokens": null
+      },
+      "parameters": {
+        "temperature": {
+          "supported": true,
+          "range": [
+            0.0,
+            1.0
+          ],
+          "default": 0.7
+        },
+        "top_p": {
+          "supported": true,
+          "range": [
+            0.0,
+            1.0
+          ],
+          "default": null
+        },
+        "top_k": {
+          "supported": true,
+          "range": [
+            1,
+            100
+          ],
+          "default": null
+        }
+      },
+      "cost": {
+        "input_per_1m_tokens": 3e-06,
+        "output_per_1m_tokens": 1.5e-05,
+        "cache_read_per_1m_tokens": null,
+        "cache_write_per_1m_tokens": null,
+        "currency": "USD",
+        "last_updated": "2026-06-15"
+      },
+      "metadata": {
+        "status": "available",
+        "release_date": "2025-05-22",
+        "deprecation_date": null,
+        "curated": true,
+        "stable": true,
+        "description": "",
+        "notes": "Routed via the Vercel AI Gateway (anthropic/claude-sonnet-4). Retired on Anthropic's native API.",
+        "size": ""
+      },
+      "rate_limits": null
+    },
+    "vercel-kimi-k2": {
+      "provider": "vercel",
+      "display_name": "Vercel: Kimi K2 (Moonshot)",
+      "aliases": [
+        "kimi-k2",
+        "kimi"
+      ],
+      "api": {
+        "model_id": "moonshotai/kimi-k2"
+      },
+      "capabilities": {
+        "streaming": true,
+        "vision": false,
+        "tool_calling": true,
+        "system_messages": true,
+        "extended_thinking": false,
+        "json_mode": true,
+        "prompt_caching": false
+      },
+      "limits": {
+        "max_context_tokens": 128000,
+        "max_output_tokens": null,
+        "max_thinking_tokens": null
+      },
+      "parameters": {
+        "temperature": {
+          "supported": true,
+          "range": [
+            0.0,
+            2.0
+          ],
+          "default": 0.7
+        },
+        "top_p": {
+          "supported": true,
+          "range": [
+            0.0,
+            1.0
+          ],
+          "default": null
+        },
+        "top_k": {
+          "supported": false,
+          "range": null,
+          "default": null
+        }
+      },
+      "cost": {
+        "input_per_1m_tokens": 5.7e-07,
+        "output_per_1m_tokens": 2.3e-06,
+        "cache_read_per_1m_tokens": null,
+        "cache_write_per_1m_tokens": null,
+        "currency": "USD",
+        "last_updated": "2026-06-15"
+      },
+      "metadata": {
+        "status": "available",
+        "release_date": null,
+        "deprecation_date": null,
+        "curated": true,
+        "stable": true,
+        "description": "",
+        "notes": "Open-weight MoE model routed via the Vercel AI Gateway (moonshotai/kimi-k2).",
+        "size": "1T total / 32B active"
+      },
+      "rate_limits": null
+    },
+    "vercel-glm-4.6": {
+      "provider": "vercel",
+      "display_name": "Vercel: GLM 4.6 (Z.ai)",
+      "aliases": [
+        "glm-4.6",
+        "glm"
+      ],
+      "api": {
+        "model_id": "zai/glm-4.6"
+      },
+      "capabilities": {
+        "streaming": true,
+        "vision": false,
+        "tool_calling": true,
+        "system_messages": true,
+        "extended_thinking": false,
+        "json_mode": true,
+        "prompt_caching": false
+      },
+      "limits": {
+        "max_context_tokens": 200000,
+        "max_output_tokens": 128000,
+        "max_thinking_tokens": null
+      },
+      "parameters": {
+        "temperature": {
+          "supported": true,
+          "range": [
+            0.0,
+            2.0
+          ],
+          "default": 0.7
+        },
+        "top_p": {
+          "supported": true,
+          "range": [
+            0.0,
+            1.0
+          ],
+          "default": null
+        },
+        "top_k": {
+          "supported": false,
+          "range": null,
+          "default": null
+        }
+      },
+      "cost": {
+        "input_per_1m_tokens": 6e-07,
+        "output_per_1m_tokens": 2.2e-06,
+        "cache_read_per_1m_tokens": null,
+        "cache_write_per_1m_tokens": null,
+        "currency": "USD",
+        "last_updated": "2026-06-15"
+      },
+      "metadata": {
+        "status": "available",
+        "release_date": "2025-09-30",
+        "deprecation_date": null,
+        "curated": true,
+        "stable": true,
+        "description": "",
+        "notes": "Open-weight coding model routed via the Vercel AI Gateway (zai/glm-4.6).",
+        "size": ""
+      },
+      "rate_limits": null
+    },
     "gemini-2.0-flash": {
       "provider": "google",
       "display_name": "gemini-2.0-flash",

--- a/pidgin/data/models_schema.json
+++ b/pidgin/data/models_schema.json
@@ -34,7 +34,7 @@
       "properties": {
         "provider": {
           "type": "string",
-          "enum": ["anthropic", "openai", "google", "xai", "ollama", "local", "silent"],
+          "enum": ["anthropic", "openai", "google", "xai", "vercel", "ollama", "local", "silent"],
           "description": "The provider that serves this model"
         },
         "display_name": {

--- a/pidgin/providers/__init__.py
+++ b/pidgin/providers/__init__.py
@@ -13,6 +13,7 @@ from .openai import OpenAIProvider
 from .silent import SilentProvider
 from .test_model import LocalTestModel
 from .token_tracker import GlobalTokenTracker
+from .vercel import VercelProvider
 from .xai import xAIProvider
 
 __all__ = [
@@ -27,6 +28,7 @@ __all__ = [
     "Provider",
     "ProviderContextManager",
     "SilentProvider",
+    "VercelProvider",
     "check_ollama_running",
     "ensure_ollama_ready",
     "start_ollama_server",

--- a/pidgin/providers/api_key_manager.py
+++ b/pidgin/providers/api_key_manager.py
@@ -19,6 +19,7 @@ class APIKeyManager:
         ProviderNames.OPENAI: EnvVars.OPENAI_API_KEY,
         ProviderNames.GOOGLE: EnvVars.GOOGLE_API_KEY,
         ProviderNames.XAI: EnvVars.XAI_API_KEY,
+        ProviderNames.VERCEL: EnvVars.AI_GATEWAY_API_KEY,
         # Aliases for backward compatibility
         "gemini": EnvVars.GEMINI_API_KEY,  # Alias for google
         "grok": EnvVars.GROK_API_KEY,  # Alias for xai

--- a/pidgin/providers/builder.py
+++ b/pidgin/providers/builder.py
@@ -9,6 +9,7 @@ from .local import LocalProvider
 from .ollama import OllamaProvider
 from .openai import OpenAIProvider
 from .silent import SilentProvider
+from .vercel import VercelProvider
 from .xai import xAIProvider
 
 
@@ -35,6 +36,8 @@ async def build_provider(model_id: str, temperature: Optional[float] = None):
         return GoogleProvider(model=api_model_id)
     elif model_config.provider == "xai":
         return xAIProvider(model=api_model_id)
+    elif model_config.provider == "vercel":
+        return VercelProvider(model=api_model_id)
     elif model_config.provider == "local":
         return LocalProvider(model_name="test")
     elif model_config.provider == "ollama":

--- a/pidgin/providers/error_utils.py
+++ b/pidgin/providers/error_utils.py
@@ -320,6 +320,13 @@ XAI_ERRORS = {
     "authentication_error": "xAI authentication failed.\n\nPlease verify:\n1. Your XAI_API_KEY is correct\n2. Your account is active\n3. You have access to Grok models",
 }
 
+VERCEL_ERRORS = {
+    "rate_limit": "Vercel AI Gateway rate limit reached.\n\nThe system will:\n1. Automatically retry with backoff\n2. Continue your conversation when ready",
+    "insufficient_quota": "Vercel AI Gateway credit balance is too low.\n\nPlease add credits or check your usage at vercel.com/dashboard.",
+    "authentication_error": "Vercel AI Gateway authentication failed.\n\nPlease verify:\n1. Your AI_GATEWAY_API_KEY is correct\n2. The key has access to the requested upstream model",
+    "model_not_found": "Model not found on the Vercel AI Gateway.\n\nPlease verify the model id uses 'provider/model' form (e.g. 'anthropic/claude-opus-4') and is available on the gateway.",
+}
+
 
 def create_anthropic_error_handler() -> ProviderErrorHandler:
     """Create error handler for Anthropic provider."""
@@ -360,5 +367,14 @@ def create_xai_error_handler() -> ProviderErrorHandler:
     return ProviderErrorHandler(
         provider_name="xAI",
         custom_errors=XAI_ERRORS,
+        custom_suppress=["rate_limit", "insufficient_quota"],
+    )
+
+
+def create_vercel_error_handler() -> ProviderErrorHandler:
+    """Create error handler for the Vercel AI Gateway provider."""
+    return ProviderErrorHandler(
+        provider_name="Vercel",
+        custom_errors=VERCEL_ERRORS,
         custom_suppress=["rate_limit", "insufficient_quota"],
     )

--- a/pidgin/providers/vercel.py
+++ b/pidgin/providers/vercel.py
@@ -1,0 +1,139 @@
+import logging
+from collections.abc import AsyncGenerator
+from typing import Dict, List, Optional
+
+from ..core.types import Message
+from .api_key_manager import APIKeyManager
+from .base import DEFAULT_MAX_TOKENS, Provider, ResponseChunk
+from .retry_utils import retry_with_exponential_backoff
+
+logger = logging.getLogger(__name__)
+
+try:
+    from openai import AsyncOpenAI
+
+    OPENAI_AVAILABLE = True
+except ImportError:
+    OPENAI_AVAILABLE = False
+    AsyncOpenAI = None  # type: ignore[assignment,misc]
+
+# Vercel AI Gateway exposes an OpenAI-compatible endpoint that proxies to many
+# upstream providers. Model IDs are sent in "provider/model" form (e.g.
+# "anthropic/claude-opus-4"), stored in each model's api.model_id.
+VERCEL_GATEWAY_BASE_URL = "https://ai-gateway.vercel.sh/v1"
+
+
+class VercelProvider(Provider):
+    def __init__(self, model: str):
+        super().__init__()
+        if not OPENAI_AVAILABLE:
+            raise ImportError(
+                "OpenAI client not available. Install with: pip install openai"
+            )
+
+        api_key = APIKeyManager.get_api_key("vercel")
+
+        # Vercel AI Gateway uses an OpenAI-compatible API with a custom base URL
+        self.client = AsyncOpenAI(api_key=api_key, base_url=VERCEL_GATEWAY_BASE_URL)
+        self.model = model
+        self._last_usage = None
+        # Use the Vercel-specific error handler
+        from .error_utils import create_vercel_error_handler
+
+        self.error_handler = create_vercel_error_handler()
+
+    async def stream_response(
+        self,
+        messages: List[Message],
+        temperature: Optional[float] = None,
+        thinking_enabled: Optional[bool] = None,
+        thinking_budget: Optional[int] = None,
+        max_tokens: Optional[int] = None,
+    ) -> AsyncGenerator[ResponseChunk, None]:
+        # Note: thinking_enabled and thinking_budget are not used; the gateway
+        # exposes a plain OpenAI-compatible chat completion surface.
+        # Apply context truncation
+        from .context_utils import apply_context_truncation
+
+        truncated_messages = apply_context_truncation(
+            messages,
+            provider="vercel",
+            model=self.model,
+            logger_name=__name__,
+            allow_truncation=self.allow_truncation,
+        )
+
+        # Convert to OpenAI format (the gateway is OpenAI-compatible)
+        openai_messages = [
+            {"role": m.role, "content": m.content} for m in truncated_messages
+        ]
+
+        # Define inner function for retry wrapper
+        async def _make_api_call():
+            # Build parameters
+            params = {
+                "model": self.model,
+                "messages": openai_messages,
+                "max_tokens": max_tokens or DEFAULT_MAX_TOKENS,
+                "stream": True,
+                "stream_options": {
+                    "include_usage": True
+                },  # Request usage data like OpenAI
+            }
+
+            # Add temperature if specified
+            if temperature is not None:
+                params["temperature"] = temperature
+
+            stream = await self.client.chat.completions.create(**params)
+
+            async for chunk in stream:
+                # Handle content chunks
+                if (
+                    chunk.choices
+                    and len(chunk.choices) > 0
+                    and chunk.choices[0].delta.content
+                ):
+                    yield ResponseChunk(chunk.choices[0].delta.content, "response")
+
+                # Check for usage data in the final chunk
+                if hasattr(chunk, "usage") and chunk.usage:
+                    self._last_usage = {
+                        "prompt_tokens": getattr(chunk.usage, "prompt_tokens", 0),
+                        "completion_tokens": getattr(
+                            chunk.usage, "completion_tokens", 0
+                        ),
+                        "total_tokens": getattr(chunk.usage, "total_tokens", 0),
+                    }
+                    logger.debug(f"Vercel usage data captured: {self._last_usage}")
+
+        # Initialize usage tracking
+        self._last_usage = None
+
+        # Use retry wrapper with exponential backoff
+        try:
+            async for response_chunk in retry_with_exponential_backoff(
+                _make_api_call,
+                max_retries=3,
+                base_delay=1.0,
+                retry_on=(Exception,),  # Retry on all exceptions
+            ):
+                # Filter out status message strings, only yield ResponseChunk
+                if isinstance(response_chunk, ResponseChunk):
+                    yield response_chunk
+        except Exception as e:
+            # Get friendly error message
+            friendly_error = self.error_handler.get_friendly_error(e)
+
+            # Log appropriately based on error type
+            if self.error_handler.should_suppress_traceback(e):
+                logger.info(f"Expected API error: {friendly_error}")
+            else:
+                logger.error(f"Unexpected API error: {e!s}", exc_info=True)
+
+            # Create a clean exception with friendly message
+            raise Exception(friendly_error) from None
+
+    def get_last_usage(self) -> Optional[Dict[str, int]]:
+        """Get token usage from the last API call."""
+        return self._last_usage


### PR DESCRIPTION
Adds a 'vercel' provider routing through the OpenAI-compatible Vercel AI
Gateway (https://ai-gateway.vercel.sh/v1), keyed off AI_GATEWAY_API_KEY.
Registers Claude Opus 4 and Sonnet 4 (retired on Anthropic's native API
but still served by the gateway), plus open-weight Kimi K2 and GLM 4.6.

https://claude.ai/code/session_01PbHiPiSWr1XsX6bzrXnYGL